### PR TITLE
Upgrade provider and add a README

### DIFF
--- a/solidblocks-hetzner/modules/rds-postgresql/README.md
+++ b/solidblocks-hetzner/modules/rds-postgresql/README.md
@@ -1,0 +1,60 @@
+# RDS PostgreSQL
+
+You can write documentation here as a preamble.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_hcloud"></a> [hcloud](#requirement\_hcloud) | 1.38.2 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | 3.3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_hcloud"></a> [hcloud](#provider\_hcloud) | 1.38.2 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [hcloud_server.rds](https://registry.terraform.io/providers/hetznercloud/hcloud/1.38.2/docs/resources/server) | resource |
+| [hcloud_volume_attachment.backup](https://registry.terraform.io/providers/hetznercloud/hcloud/1.38.2/docs/resources/volume_attachment) | resource |
+| [hcloud_volume_attachment.data](https://registry.terraform.io/providers/hetznercloud/hcloud/1.38.2/docs/resources/volume_attachment) | resource |
+| [hcloud_volume.backup](https://registry.terraform.io/providers/hetznercloud/hcloud/1.38.2/docs/data-sources/volume) | data source |
+| [hcloud_volume.data](https://registry.terraform.io/providers/hetznercloud/hcloud/1.38.2/docs/data-sources/volume) | data source |
+| [http_http.cloud_init_bootstrap_solidblocks](https://registry.terraform.io/providers/hashicorp/http/3.3.0/docs/data-sources/http) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_backup_full_calendar"></a> [backup\_full\_calendar](#input\_backup\_full\_calendar) | systemd timer spec for full backups | `string` | `"*-*-* 20:00:00"` | no |
+| <a name="input_backup_incr_calendar"></a> [backup\_incr\_calendar](#input\_backup\_incr\_calendar) | systemd timer spec for incremental backups | `string` | `"*-*-* *:00:55"` | no |
+| <a name="input_backup_s3_access_key"></a> [backup\_s3\_access\_key](#input\_backup\_s3\_access\_key) | AWS access key for S3 backups. To enable S3 backups 'backup\_s3\_bucket', 'backup\_s3\_access\_key' and 'backup\_s3\_secret\_key' have to be provided. | `string` | `null` | no |
+| <a name="input_backup_s3_bucket"></a> [backup\_s3\_bucket](#input\_backup\_s3\_bucket) | AWS bucket name for S3 backups. To enable S3 backups 'backup\_s3\_bucket', 'backup\_s3\_access\_key' and 'backup\_s3\_secret\_key' have to be provided. | `string` | `null` | no |
+| <a name="input_backup_s3_secret_key"></a> [backup\_s3\_secret\_key](#input\_backup\_s3\_secret\_key) | AWS secret key for S3 backups. To enable S3 backups 'backup\_s3\_bucket', 'backup\_s3\_access\_key' and 'backup\_s3\_secret\_key' have to be provided. | `string` | `null` | no |
+| <a name="input_backup_volume"></a> [backup\_volume](#input\_backup\_volume) | backup volume id | `number` | `0` | no |
+| <a name="input_data_volume"></a> [data\_volume](#input\_data\_volume) | data volume id | `number` | n/a | yes |
+| <a name="input_databases"></a> [databases](#input\_databases) | A list of databases to create when the instance is initialized, for example: '{ id : "database1", user : "user1", password : "password1" }' | `list(object({ id : string, user : string, password : string }))` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | hetzner location | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | unique name for the postgres rds instance | `string` | n/a | yes |
+| <a name="input_server_type"></a> [server\_type](#input\_server\_type) | hetzner cloud server type | `string` | `"cx11"` | no |
+| <a name="input_solidblocks_base_url"></a> [solidblocks\_base\_url](#input\_solidblocks\_base\_url) | override base url for testing purposes | `string` | `"https://github.com"` | no |
+| <a name="input_solidblocks_cloud_init_version"></a> [solidblocks\_cloud\_init\_version](#input\_solidblocks\_cloud\_init\_version) | n/a | `string` | `"v0.0.84"` | no |
+| <a name="input_solidblocks_version"></a> [solidblocks\_version](#input\_solidblocks\_version) | n/a | `string` | `"v0.0.84"` | no |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | ssh keys for instance access | `list(number)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ipv4_address"></a> [ipv4\_address](#output\_ipv4\_address) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/solidblocks-hetzner/modules/rds-postgresql/versions.tf
+++ b/solidblocks-hetzner/modules/rds-postgresql/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.38.0"
+      version = "1.38.2"
     }
     http = {
       source  = "hashicorp/http"
-      version = "3.2.1"
+      version = "3.3.0"
     }
   }
 }


### PR DESCRIPTION
This PR upgrades the hcloud provider. Unfortunately, this provider does not support greedy matching using the `~>` operator. 

It also adds a generated README file which was produced by terraform-docs

```
terraform-docs markdown table .
```
