### PR TITLE
fix: Change label variable type to satisfy terraform validate.

### DIFF
--- a/solidblocks-hetzner/modules/rds-postgresql/variables.tf
+++ b/solidblocks-hetzner/modules/rds-postgresql/variables.tf
@@ -84,7 +84,7 @@ variable "solidblocks_version" {
 }
 
 variable "labels" {
-  type        = object
+  type        = map(any)
   description = "A list of labels to be attached to the server instance."
   default     = {}
 }


### PR DESCRIPTION
When using version 0.1.0, terraform complained about the label being an object without proper object definition. As labels can be anything, I changed the type to `map`. Now `terraform validate` runs successfully. The PR fixes the following error message:

```
The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Invalid type specification
│ 
│   on .terraform/modules/rds-postgresql/solidblocks-hetzner/modules/rds-postgresql/variables.tf line 87, in variable "labels":
│   87:   type        = object
│ 
│ The object type constructor requires one argument specifying the attribute types and values as a map.
```