### PR TITLE
feat: allow setting db admin password

### DIFF
--- a/solidblocks-hetzner/modules/rds-postgresql/main.tf
+++ b/solidblocks-hetzner/modules/rds-postgresql/main.tf
@@ -22,6 +22,8 @@ locals {
     environment_variables = var.environment_variables
     postgres_stop_timeout = var.postgres_stop_timeout
 
+    db_admin_password = var.db_admin_password
+
     ssl_enable              = var.ssl_enable
     ssl_email               = var.ssl_email
     ssl_domains             = var.ssl_domains

--- a/solidblocks-hetzner/modules/rds-postgresql/user_data.sh
+++ b/solidblocks-hetzner/modules/rds-postgresql/user_data.sh
@@ -136,6 +136,9 @@ services:
       - "DB_USERNAME_${database.id}=${database.user}"
       - "DB_PASSWORD_${database.id}=${database.password}"
       %{~ endfor ~}
+      %{~ if db_admin_password != "" ~}
+      - "DB_ADMIN_PASSWORD=${db_admin_password}"
+      %{~ endif ~}
       %{~ for key, value in environment_variables ~}
       - "${key}=${value}"
       %{~ endfor ~}

--- a/solidblocks-hetzner/modules/rds-postgresql/variables.tf
+++ b/solidblocks-hetzner/modules/rds-postgresql/variables.tf
@@ -73,6 +73,7 @@ variable "backup_incr_calendar" {
 
 variable "databases" {
   type        = list(object({ id : string, user : string, password : string }))
+  sensitive   = true
   description = "A list of databases to create when the instance is initialized, for example: `{ id : \"database1\", user : \"user1\", password : \"password1\" }`. Changing `user` and `password` is supported at any time, the provided config is translated into an config for the Solidblocks RDS PostgreSQL module (https://pellepelster.github.io/solidblocks/rds/index.html), please see https://pellepelster.github.io/solidblocks/rds/index.html#databases for more details of the database configuration."
 }
 
@@ -80,6 +81,14 @@ variable "environment_variables" {
   type        = map(string)
   description = "A list environment variables to pass to the PostgreSQL  docker container"
   default     = {}
+}
+
+
+variable "db_admin_password" {
+  type        = string
+  sensitive   = true
+  default     = ""
+  description = "The database admin password. Username is always rds"
 }
 
 variable "postgres_major_version" {


### PR DESCRIPTION
This is helpful if you want to use some other tool to manage the postgres databases & roles. For example, this can be used with a postgres terraform provider.

As requested here: https://github.com/apricote/solidblocks/commit/861a59dc0cbf669498e657ad68c9e426bcbd17b3#commitcomment-129778768  
Not sure if you still want this change, as e2676485f6c4cc80857da6460bdf7cd595c95b02 also makes it possible to add the admin password.