### PR TITLE
feat: allow configuring ACME server

### DIFF
--- a/solidblocks-hetzner/modules/rds-postgresql/main.tf
+++ b/solidblocks-hetzner/modules/rds-postgresql/main.tf
@@ -29,6 +29,7 @@ locals {
     ssl_domains             = var.ssl_domains
     ssl_dns_provider        = var.ssl_dns_provider
     ssl_dns_provider_config = var.ssl_dns_provider_config
+    ssl_acme_server         = var.ssl_acme_server
     postgres_major_version  = var.postgres_major_version
     postgres_extra_config   = var.postgres_extra_config == null ? "" : var.postgres_extra_config
 

--- a/solidblocks-hetzner/modules/rds-postgresql/user_data.sh
+++ b/solidblocks-hetzner/modules/rds-postgresql/user_data.sh
@@ -13,6 +13,7 @@ STORAGE_DEVICE_DATA="${storage_device_data}"
 SSL_ENABLE="${ssl_enable}"
 SSL_EMAIL="${ssl_email}"
 SSL_DNS_PROVIDER="${ssl_dns_provider}"
+SSL_ACME_SERVER="${ssl_acme_server}"
 
 SSL_DOMAINS=""
 %{ for domain in ssl_domains }
@@ -193,7 +194,7 @@ configure_ufw
 if [[ "$${SSL_ENABLE}" == "true" ]]; then
   lego_run_hook_script > ~rds/lego_run_hook.sh
   chmod +x ~rds/lego_run_hook.sh
-  lego_setup_dns "/storage/data/ssl" "$${SSL_EMAIL}" "$${SSL_DOMAINS}" "$${SSL_DNS_PROVIDER}" "$(readlink -f ~rds/lego_run_hook.sh)" "https://acme-staging-v02.api.letsencrypt.org/directory"
+  lego_setup_dns "/storage/data/ssl" "$${SSL_EMAIL}" "$${SSL_DOMAINS}" "$${SSL_DNS_PROVIDER}" "$(readlink -f ~rds/lego_run_hook.sh)" "$${SSL_ACME_SERVER}"
 fi
 
 mkdir -p "/opt/dockerfiles/${db_instance_name}"

--- a/solidblocks-hetzner/modules/rds-postgresql/variables.tf
+++ b/solidblocks-hetzner/modules/rds-postgresql/variables.tf
@@ -193,6 +193,13 @@ variable "ssl_dns_provider_config" {
   default     = {}
 }
 
+variable "ssl_acme_server" {
+  type = string
+  description = "The URL of the ACME Server to use. Defaults to Let's Encrypt production environment."
+  # LetsEncrypt Staging: https://acme-staging-v02.api.letsencrypt.org/directory
+  default = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
 variable "backup_encryption_passphrase" {
   type        = string
   description = "If set the backups will be encrypted using this passphrase"


### PR DESCRIPTION
Make the ACME server used for certificates configurable.

Change the default from LetsEncrypt staging to LetsEncrypt production.

Closes #21 