### PR TITLE
Install pg_cron and pg_remote_exec extension

### DIFF
--- a/solidblocks-rds-postgresql/Dockerfile
+++ b/solidblocks-rds-postgresql/Dockerfile
@@ -1,5 +1,19 @@
 ARG ALPINE_VERSION=""
 
+FROM alpine:${ALPINE_VERSION} AS builder
+
+ARG POSTGRES_VERSION=""
+
+RUN apk upgrade --available
+RUN apk add \
+	git \
+	make \
+	postgresql${POSTGRES_VERSION}-dev
+
+RUN git clone https://github.com/cybertec-postgresql/pg_remote_exec.git && cd pg_remote_exec && make install
+
+ARG ALPINE_VERSION=""
+
 FROM alpine:${ALPINE_VERSION}
 
 ARG POSTGRES_VERSION=""
@@ -35,6 +49,7 @@ RUN apk add \
     postgresql${POSTGRES_PREVIOUS_VERSION}-contrib \
     postgresql${POSTGRES_VERSION} \
     postgresql${POSTGRES_VERSION}-contrib \
+    postgresql-pg_cron \
     jq \
     bash \
     coreutils \
@@ -53,6 +68,12 @@ RUN mkdir -p /run/postgresql/ && chown -R ${USER}:${USER} /run/postgresql/
 
 COPY install/ /tmp/install/
 RUN /tmp/install/install_gomplate.sh && rm -rf /tmp/install/
+
+COPY --from=builder /usr/lib/postgresql${POSTGRES_VERSION}/pg_remote_exec.so /usr/lib/postgresql${POSTGRES_VERSION}/
+COPY --from=builder /usr/lib/postgresql${POSTGRES_VERSION}/bitcode/pg_remote_exec /usr/lib/postgresql${POSTGRES_VERSION}/bitcode/pg_remote_exec
+COPY --from=builder /usr/lib/postgresql${POSTGRES_VERSION}/bitcode/pg_remote_exec.* /usr/lib/postgresql${POSTGRES_VERSION}/bitcode/
+COPY --from=builder /usr/share/postgresql${POSTGRES_VERSION}/extension/pg_remote_exec* /usr/share/postgresql${POSTGRES_VERSION}/extension/
+COPY --from=builder /usr/share/doc/postgresql${POSTGRES_VERSION}/extension/pg_remote_exec* /usr/share/doc/postgresql${POSTGRES_VERSION}/extension/
 
 USER ${USER}
 


### PR DESCRIPTION
Install [`pg_cron`](https://github.com/citusdata/pg_cron) and [`pg_remote_exec`](https://github.com/cybertec-postgresql/pg_remote_exec) extensions in PostgreSQL database, so that it is possible to schedule backups using postgres-only solution.