### PR TITLE
Fix failing build after adding pg_remote_exec

### DIFF
--- a/solidblocks-rds-postgresql/Dockerfile
+++ b/solidblocks-rds-postgresql/Dockerfile
@@ -1,18 +1,16 @@
-ARG ALPINE_VERSION=""
+ARG ALPINE_VERSION="3.21.3"
 
 FROM alpine:${ALPINE_VERSION} AS builder
 
-ARG POSTGRES_VERSION=""
-
 RUN apk upgrade --available
 RUN apk add \
-	git \
-	make \
-	postgresql${POSTGRES_VERSION}-dev
+    git \
+    make \
+    gcc \
+    libc-dev \
+    postgresql-dev
 
 RUN git clone https://github.com/cybertec-postgresql/pg_remote_exec.git && cd pg_remote_exec && make install
-
-ARG ALPINE_VERSION=""
 
 FROM alpine:${ALPINE_VERSION}
 

--- a/solidblocks-rds-postgresql/do
+++ b/solidblocks-rds-postgresql/do
@@ -56,22 +56,23 @@ function task_test {
 
 function task_build {
   (
+    typeset -A alpine_ver_by_postgres_ver
+    alpine_ver_by_postgres_ver["17"]="3.21.3";
+    alpine_ver_by_postgres_ver["16"]="3.20.6";
+    alpine_ver_by_postgres_ver["15"]="3.18.12";
+    alpine_ver_by_postgres_ver["14"]="3.16.9";
+
     cd "${DIR}"
     mkdir -p "${DIR}/build"
 
     for postgres_version in ${POSTGRES_VERSIONS}; do
-      local alpine_version="3.21.2"
-
-      if [[ "${postgres_version}" -lt "16" ]]; then
-        alpine_version="3.19.6"
-      fi
 
       docker buildx build \
         --platform linux/arm,linux/amd64,linux/arm64 \
         --push \
         --build-arg POSTGRES_VERSION=${postgres_version} \
         --build-arg POSTGRES_PREVIOUS_VERSION=$((postgres_version-1)) \
-        --build-arg ALPINE_VERSION=${alpine_version} \
+        --build-arg ALPINE_VERSION=${alpine_ver_by_postgres_ver["$postgres_version"]} \
         --tag "${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${DOCKER_IMAGE_NAME}:${postgres_version}-${VERSION}-rc" \
         .
     done


### PR DESCRIPTION
# Issue background

PostgreSQL runtime is using `pg_versions` to switch between a number of installed versions. Same technique cannot be used for the `-dev` package that was added earlier as a builder pattern to build `pg_remote_exec` extension from source (no alpine package is available for that extension).

# Solution

In order to have the correct version of PostgreSQL sources (`-dev` package), a matching alpine linux version has been identified that has a chosen PostgreSQL version as default. This step was done manually by browsing the contents of [packages](https://pkgs.alpinelinux.org/packages?name=postgresql1*&branch=v3.16) matching a pattern `postgresql*` for a given alpine linux version chosen as a filter. Based on that information, in the shell script the associative array `alpine_ver_by_postgres_ver` stores this mapping.

# Testing
The build process has been tested locally for building PostgreSQL versions: 14, 15, 16, 17. Previously the test was done only for 17 and this is how the bug was introduced.
The build process has **NOT** been tested for many platforms, due to the following error message on my local system:
```
ERROR: Multi-platform build is not supported for the docker driver.
```

# Important Note

Historical build artifact build process has been altered. For different versions of postgres, now a different alpine linux image is used that was before. I believe this is desired, but in case it isn't I can create a code change that will leave alpine linux versions as they were.